### PR TITLE
layoutの共通化とログイン画面の作成

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from "next";
 import "./globals.css";
-
+import NotLoginLayout from "@/components/templates/NotLoginLayout";
 
 export const metadata: Metadata = {
   title: "Create Next App",
@@ -14,7 +14,11 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
-      <body>{children}</body>
+      <body>
+        <NotLoginLayout>
+          {children}
+        </NotLoginLayout>
+      </body>
     </html>
   );
 }

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,0 +1,13 @@
+import React from 'react'
+
+const page = () => {
+  return (
+    <div>
+        <h1>
+            page
+        </h1>
+    </div>
+  )
+}
+
+export default page

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -17,7 +17,6 @@ const Home: React.FC = () => {
         </div>
       </header>
       <main className="pt-[50px] bg-gradient-to-r from-lime-100 to-lime-200 h-screen flex flex-col justify-center items-center">
-      <NotLoginLayout>
         <div className="text-center">
           <h1 className="text-7xl logo">スケジュール管理</h1>
           <p className="pt-[10vh] text-5xl">
@@ -27,7 +26,6 @@ const Home: React.FC = () => {
               <PrimaryBtn>ログイン</PrimaryBtn>
           </div>
         </div>
-        </NotLoginLayout>
       </main>
     </div>
   );

--- a/src/components/templates/NotLoginLayout.tsx
+++ b/src/components/templates/NotLoginLayout.tsx
@@ -22,7 +22,7 @@ export const NotLoginLayout = ({ children }:PropsType) => {
         {children}
       </main>
     </div>
-  );
+    );
 }
 
 export default NotLoginLayout;


### PR DESCRIPTION
### wiki
https://github.com/Hashimoto-Noriaki/next-calender-app/wiki/%E6%89%8B%E9%A0%869-%E3%83%AD%E3%82%B0%E3%82%A4%E3%83%B3%E6%A9%9F%E8%83%BD%E4%BD%9C%E6%88%901


### 変更点
- src/app/layout.tsx
- src/app/login/page.tsx
- src/app/page.tsx
- src/components/templates/NotLoginLayout.tsx

### 動作

<img width="1432" alt="スクリーンショット 2024-07-01 5 52 00" src="https://github.com/Hashimoto-Noriaki/next-calender-app/assets/73786052/fb28aaba-3de7-4e6a-87e9-2a33cded2b31">
