### PR TITLE
ログイン画面を作成(ヘッダーのロゴをクリックした際にTopページ、右上のログインとログインボタンクリックした際にログインページに遷移

### DIFF
--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,3 +1,5 @@
+"use client"
+
 import { Input } from "../../components//atoms/Input";
 import { PrimaryBtn } from "../../components/atoms/PrimaryBtn";
 
@@ -20,7 +22,7 @@ export const Login = () => {
             placeholder="password"
           />
         </div>
-        <PrimaryBtn>ログイン</PrimaryBtn>
+        <PrimaryBtn onClick={() => null}>ログイン</PrimaryBtn>
       </form>
     </div>
   );

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,7 +1,16 @@
+"use client";
+
 import React from 'react';
+import { useRouter } from 'next/navigation';
 import { PrimaryBtn } from "../components/atoms/PrimaryBtn";
 
 const Home: React.FC = () => {
+  const router = useRouter();
+
+  const handleLoginClick = () => {
+    router.push('/login');// ログインページに遷移
+  }
+
   return (
     <main className="pt-[50px] bg-gradient-to-r from-lime-100 to-lime-200 h-screen flex flex-col justify-center items-center">
       <div className="text-center">
@@ -10,7 +19,7 @@ const Home: React.FC = () => {
           お互いのスケジュールを管理するアプリです。
         </p>
         <div className="pt-[20vh]">
-          <PrimaryBtn>ログイン</PrimaryBtn>
+          <PrimaryBtn onClick={handleLoginClick}>ログイン</PrimaryBtn>
         </div>
       </div>
     </main>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,33 +1,19 @@
-import React from 'react'
+import React from 'react';
 import { PrimaryBtn } from "../components/atoms/PrimaryBtn";
-import { NotLoginLayout } from '../components/templates/NotLoginLayout';
 
 const Home: React.FC = () => {
-  return(
-    <div className="relative">
-      <header className="bg-white line-height:50px; fixed top-0 left-0 right-0">
-        <div className="container mx-auto flex justify-between">
-          <p className="logo">スケジュール管理APP</p>
-          <nav>
-            <ul className="flex gap-5 text-lime-800">
-              <li>ご利用方法</li>
-              <li>ログイン</li>
-            </ul>
-          </nav>
+  return (
+    <main className="pt-[50px] bg-gradient-to-r from-lime-100 to-lime-200 h-screen flex flex-col justify-center items-center">
+      <div className="text-center">
+        <h1 className="text-7xl logo">スケジュール管理</h1>
+        <p className="pt-[10vh] text-5xl">
+          お互いのスケジュールを管理するアプリです。
+        </p>
+        <div className="pt-[20vh]">
+          <PrimaryBtn>ログイン</PrimaryBtn>
         </div>
-      </header>
-      <main className="pt-[50px] bg-gradient-to-r from-lime-100 to-lime-200 h-screen flex flex-col justify-center items-center">
-        <div className="text-center">
-          <h1 className="text-7xl logo">スケジュール管理</h1>
-          <p className="pt-[10vh] text-5xl">
-            お互いのスケジュールを管理するアプリです。
-          </p>
-          <div className="pt-[20vh]">
-              <PrimaryBtn>ログイン</PrimaryBtn>
-          </div>
-        </div>
-      </main>
-    </div>
+      </div>
+    </main>
   );
 };
 

--- a/src/components/atoms/PrimaryBtn.tsx
+++ b/src/components/atoms/PrimaryBtn.tsx
@@ -1,13 +1,16 @@
+"use client"
+
 import { ReactNode } from 'react'
 
 type PropsType = {
+    onClick: () => void
     children:ReactNode
 } 
 
-export const PrimaryBtn = ({ children }: PropsType) => {
+export const PrimaryBtn = ({ onClick,children }: PropsType) => {
   return (
-    <button className="bg-lime-800 text-white p-4 text-lg rounded-lg">
-        { children }
+    <button className="bg-lime-800 text-white p-4 text-lg rounded-lg" onClick={onClick}>
+      { children }
     </button>
   )
 }

--- a/src/components/templates/NotLoginLayout.tsx
+++ b/src/components/templates/NotLoginLayout.tsx
@@ -1,4 +1,5 @@
 import { ReactNode } from 'react'
+import Link from 'next/link';
 
 type PropsType = {
     children:ReactNode
@@ -9,11 +10,15 @@ export const NotLoginLayout = ({ children }:PropsType) => {
     <div className="relative">
       <header className="bg-white line-height:50px; fixed top-0 left-0 right-0">
         <div className="container mx-auto flex justify-between">
-          <p className="logo">スケジュール管理APP</p>
+          <p className="logo">
+            <Link href="/">スケジュール管理APP</Link>
+          </p>
           <nav>
             <ul className="flex gap-5 text-lime-800">
               <li>ご利用方法</li>
-              <li>ログイン</li>
+              <li>
+                <Link href="/login">ログイン</Link>
+              </li>
             </ul>
           </nav>
         </div>


### PR DESCRIPTION
### wiki

https://github.com/Hashimoto-Noriaki/next-calender-app/wiki/%E6%89%8B%E9%A0%8611%E3%83%AD%E3%82%B0%E3%82%A4%E3%83%B3%E7%94%BB%E9%9D%A2%E3%81%AE%E4%BD%9C%E6%88%904

### 変更点
- src/app/login/page.tsx
- src/app/page.tsx
- src/components/atoms/PrimaryBtn.tsx
- src/components/templates/NotLoginLayout.tsx

<img width="1436" alt="スクリーンショット 2024-07-02 0 35 06" src="https://github.com/Hashimoto-Noriaki/next-calender-app/assets/73786052/47f651df-60ef-49e3-9a3d-fba955380be3">

<img width="1431" alt="スクリーンショット 2024-07-02 0 35 59" src="https://github.com/Hashimoto-Noriaki/next-calender-app/assets/73786052/80f4e134-f3b7-49d9-8ec8-100d0e59820d">


