### PR TITLE
 ログインフォームをstateにて管理できるようにし、ログイン失敗時のエラーハンドリングを追加

### DIFF
--- a/src/api/login.ts
+++ b/src/api/login.ts
@@ -1,0 +1,10 @@
+import { LoginInfoType, LoginReturnType } from "../types/login"
+
+export const login = (info: LoginInfoType): LoginReturnType => {
+  const { email, password } = info
+  if (email === "test@example.com" && password === "password") {
+    return { id: 1, name: "sample太郎" }
+  } else {
+    throw new Error()
+  }
+};

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,25 +1,60 @@
-"use client"
+"use client";
 
-import { Input } from "../../components//atoms/Input";
+import { ChangeEvent, FormEvent, useState } from "react";
+import { Input } from "../../components/atoms/Input";
 import { PrimaryBtn } from "../../components/atoms/PrimaryBtn";
+import { LoginInfoType } from "../../types/login";
+import { login } from "../../api/login";
 
 export const Login = () => {
+  const [loginInfo, setLoginInfo] = useState<LoginInfoType>({
+    email: "",
+    password: "",
+  })
+  const [errorMessage, setErrorMessage] = useState("");
+
+  const changeLoginInfo = (event: ChangeEvent<HTMLInputElement>) => {
+    const { name, value } = event.target
+    setLoginInfo({ ...loginInfo, [name]: value })
+  }
+
+  const handleLogin = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+    setErrorMessage("")
+    try {
+      login(loginInfo)
+    } catch {
+      setErrorMessage("ログインに失敗しました");
+    }
+  };
+
   return (
     <div className="w-[500px] bg-white rounded-lg shadow-lg py-10">
-      <form className="flex flex-col justify-center items-center gap-10">
+      <form className="flex flex-col justify-center items-center gap-10" onSubmit={handleLogin}>
         <h1 className="text-3xl text-lime-800 font-bold text-center">
           ログイン
         </h1>
+        {errorMessage !== "" && (
+          <div className="p-5 bg-red-500 text-white w-[80%] rounded-lg">
+            {errorMessage}
+          </div>
+        )}
         <div className="w-[80%]">
           <Input
+            name="email"
             type="text"
             placeholder="email"
+            value={loginInfo.email}
+            onChange={changeLoginInfo}
           />
         </div>
         <div className="w-[80%]">
           <Input
+            name="password"
             type="password"
             placeholder="password"
+            value={loginInfo.password}
+            onChange={changeLoginInfo}
           />
         </div>
         <PrimaryBtn onClick={() => null}>ログイン</PrimaryBtn>

--- a/src/types/login.ts
+++ b/src/types/login.ts
@@ -1,0 +1,9 @@
+export type LoginInfoType = {
+    email:string;
+    password:string;
+}
+
+export type LoginReturnType = {
+    id: number
+    name: string
+}


### PR DESCRIPTION
### wiki
https://github.com/Hashimoto-Noriaki/next-calender-app/wiki/%E6%89%8B%E9%A0%8613-%E3%83%AD%E3%82%B0%E3%82%A4%E3%83%B3%E6%A9%9F%E8%83%BD%E3%81%AE%E4%BD%9C%E6%88%901

### 変更点
- src/api/login.ts
- src/app/login/page.tsx
- src/types/login.ts

### 確認

<img width="1434" alt="スクリーンショット 2024-07-02 18 12 56" src="https://github.com/Hashimoto-Noriaki/next-calender-app/assets/73786052/e24abe90-3d0d-4ea2-aa55-d68ea97014f6">



